### PR TITLE
Rework `applyGuardMounting` (without using `Comment`)

### DIFF
--- a/src/jsx/ProtonJSX.ts
+++ b/src/jsx/ProtonJSX.ts
@@ -17,7 +17,7 @@ namespace ProtonJSX {
   }
 
 
-  export class Intrinsic extends Node { override type!: keyof never; override props?: any }
+  export class Intrinsic extends Node { override type!: string; override props?: any }
   export class Component extends Node { override type!: Function }
   export class Fragment extends Node { }
 


### PR DESCRIPTION
Now it "guarded elements" won't be replaced with a comment node, instead the element itself will stay, but the children are removed until it's "unguarded" (mounted).